### PR TITLE
새로 고침 시 로그인이 풀리는 버그 수정과 그에 따른 hook과 컴포넌트 로직 수정 (after #69 merged)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,10 @@ import ServicePage from './pages/ServicePage';
 import SigninPage from './pages/SigninPage';
 import SignupPage from './pages/SignupPage';
 import PrivateRoute from './components/common/PrivateRoute';
-import { useUserStateValue } from './atoms/userState';
+import useAutoLogin from './hooks/useAutoLogin';
 
 const App: FC = () => {
-  const user = useUserStateValue();
-
-  const isAuthenticated = !!user;
+  const { isLoggedIn } = useAutoLogin();
 
   return (
     <ErrorBoundary>
@@ -25,19 +23,19 @@ const App: FC = () => {
           path={Uri.signup}
           exact
           component={SignupPage}
-          isAccessible={!isAuthenticated}
+          isAccessible={!isLoggedIn}
         />
         <PrivateRoute
           path={Uri.signin}
           exact
           component={SigninPage}
-          isAccessible={!isAuthenticated}
+          isAccessible={!isLoggedIn}
         />
         <PrivateRoute
           path={Uri.service}
           exact
           component={ServicePage}
-          isAccessible={isAuthenticated}
+          isAccessible={isLoggedIn}
         />
         <Route path={Uri.serviceEdit} exact component={ServiceEditPage} />
         <Route component={NotFoundPage} />

--- a/src/components/common/Navbar/index.tsx
+++ b/src/components/common/Navbar/index.tsx
@@ -1,21 +1,20 @@
 import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useUserState } from '@/atoms/userState';
 import useConfirmModal from '@/hooks/useConfirmModal';
 import Uri from '@/constants/uri';
 import PrivateNavbar from '@/components/nav/PrivateNavbar';
 import PublicNavbar from '@/components/nav/PublicNavbar';
 import Logo from '@/components/common/Logo';
+import useAuth from '@/hooks/useAuth';
 
 import { navStyle } from './style';
 
 const Navbar: FC = () => {
-  const [user, setUser] = useUserState();
+  const { user, logout } = useAuth();
   const [open] = useConfirmModal();
 
   const logoutHandler = () => {
-    const logout = () => setUser(null);
     open({ message: 'Do you want to logout?', acceptHandler: logout });
   };
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { authApi } from '@/apis';
-import { LoginRequestBody } from '@/types';
 import { useSetUserState } from '@/atoms/userState';
-import { NETWORK_ERROR, loginError, UNEXPECTED_ERROR } from '@/constants/error';
+import { NETWORK_ERROR, UNEXPECTED_ERROR, loginError } from '@/constants/error';
 import Uri from '@/constants/uri';
+import { LoginRequestBody } from '@/types';
 
 const useAuth = (): {
   login: ({ userId, password }: LoginRequestBody) => Promise<void>;
@@ -24,9 +24,11 @@ const useAuth = (): {
 
       await authApi.login({ userId, password });
 
-      // @TODO 로그인 성공 시 사용자 정보 가져오는 API 호출 후 상태로 저장
+      setUserState((prev) => ({ ...prev, userId }));
 
-      history.replace(Uri.home);
+      setIsLoading(false);
+
+      history.replace(Uri.service);
     } catch (e) {
       if (e.response) {
         if (loginError[e.response.status]) {
@@ -37,9 +39,10 @@ const useAuth = (): {
       } else {
         setError(NETWORK_ERROR);
       }
-      throw e;
-    } finally {
+
       setIsLoading(false);
+
+      throw e;
     }
   };
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,18 +2,19 @@ import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { authApi } from '@/apis';
-import { useSetUserState } from '@/atoms/userState';
+import { useUserState } from '@/atoms/userState';
 import { NETWORK_ERROR, UNEXPECTED_ERROR, loginError } from '@/constants/error';
 import Uri from '@/constants/uri';
-import { LoginRequestBody } from '@/types';
+import { LoginRequestBody, User } from '@/types';
 
 const useAuth = (): {
+  user: User;
   login: ({ userId, password }: LoginRequestBody) => Promise<void>;
   logout: () => void;
   isLoading: boolean;
   error: string;
 } => {
-  const setUserState = useSetUserState();
+  const [user, setUserState] = useUserState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const history = useHistory();
@@ -25,6 +26,8 @@ const useAuth = (): {
       await authApi.login({ userId, password });
 
       setUserState((prev) => ({ ...prev, userId }));
+
+      localStorage.setItem('userId', userId);
 
       setIsLoading(false);
 
@@ -48,12 +51,14 @@ const useAuth = (): {
 
   const logout = () => {
     setUserState(null);
-    authApi.logout().catch(() => {
-      /* 로그아웃의 경우, 별도의 에러 처리를 하지 않음 */
-    });
+
+    localStorage.removeItem('userId');
+
+    authApi.logout();
   };
 
   return {
+    user,
     login,
     logout,
     isLoading,

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -54,7 +54,9 @@ const useAuth = (): {
 
     localStorage.removeItem('userId');
 
-    authApi.logout();
+    authApi.logout().catch(() => {
+      /* 로그아웃의 경우, 별도의 에러 처리를 하지 않음 */
+    });
   };
 
   return {

--- a/src/hooks/useAutoLogin.ts
+++ b/src/hooks/useAutoLogin.ts
@@ -1,25 +1,29 @@
 import { useEffect, useState } from 'react';
 
 import { authApi } from '@/apis';
-import { useUserStateValue } from '@/atoms/userState';
+import { useUserState } from '@/atoms/userState';
 
 const useAutoLogin = (): { isLoading: boolean; isLoggedIn: boolean } => {
-  const userState = useUserStateValue();
+  const [user, setUserState] = useUserState();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const autoLogin = async () => {
     try {
+      const userId = localStorage.getItem('userId');
+      if (!userId) return;
+
       setIsLoading(true);
 
       await authApi.refresh();
 
-      // @TODO refresh API 성공 시, 사용자 정보 가져오는 API를 호출하여 사용자 상태로 저장
-
-      setIsLoggedIn(true);
+      setUserState({ userId });
     } catch (e) {
-      setIsLoggedIn(false);
+      /* 
+        따로 에러 핸들링 해야할 것으로 보입니다.
+        refresh를 실패했다는 것은 곧 refresh token이 만료되었을 경우가 대부분일테니
+        이에 따라서 다시 로그인 해달라는 창을 보여주는 것이 어떨지.. toastify 처럼..
+      */
     } finally {
       setIsLoading(false);
     }
@@ -27,9 +31,9 @@ const useAutoLogin = (): { isLoading: boolean; isLoggedIn: boolean } => {
 
   useEffect(() => {
     autoLogin();
-  }, [userState]);
+  }, []);
 
-  return { isLoading, isLoggedIn };
+  return { isLoading, isLoggedIn: user !== null };
 };
 
 export default useAutoLogin;

--- a/src/pages/SigninPage/index.test.tsx
+++ b/src/pages/SigninPage/index.test.tsx
@@ -4,13 +4,16 @@ import { MemoryRouter, Router } from 'react-router-dom';
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { RecoilRoot } from 'recoil';
 
 import SigninPage from '.';
 
 describe('SigninPage 테스트', () => {
   const signupPageContainer = (
     <MemoryRouter>
-      <SigninPage />
+      <RecoilRoot>
+        <SigninPage />
+      </RecoilRoot>
     </MemoryRouter>
   );
 
@@ -34,7 +37,9 @@ describe('SigninPage 테스트', () => {
 
     render(
       <Router history={history}>
-        <SigninPage />
+        <RecoilRoot>
+          <SigninPage />
+        </RecoilRoot>
       </Router>,
     );
 

--- a/src/pages/SigninPage/index.tsx
+++ b/src/pages/SigninPage/index.tsx
@@ -1,21 +1,19 @@
 import React, { FC, useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { authApi } from '@/apis';
-import { useSetUserState } from '@/atoms/userState';
 import Jumbotron from '@/components/common/Jumbotron';
 import Logo from '@/components/common/Logo';
 import Shell from '@/components/shell/Shell';
 import { reject, renderProps, resolve } from '@/components/shell/helper';
 import { NETWORK_ERROR, UNEXPECTED_ERROR, loginError } from '@/constants/error';
 import Uri from '@/constants/uri';
+import useAuth from '@/hooks/useAuth';
 import { LoginRequestBody } from '@/types';
 
 import { footerStyle, headerStyle, layoutStyle } from './style';
 
 const SigninPage: FC = () => {
-  const setUserState = useSetUserState();
-  const { push } = useHistory();
+  const { login } = useAuth();
 
   const checkIsValueEmpty = useCallback(
     (option: {
@@ -37,11 +35,7 @@ const SigninPage: FC = () => {
     if (val !== 'y') return reject(2, 'Access denied');
 
     try {
-      await authApi.login(body);
-
-      setUserState((prev) => ({ ...prev, userId: body.userId }));
-
-      push(Uri.service);
+      await login(body);
 
       return resolve();
     } catch (error) {


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

새로 고침 시 로그인이 풀리는 버그를 수정하였습니다.
로직이 수정되어서 그에 따른 몇 가지 수정사항이 있습니다.

## 이슈 번호

- closes #64 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- login을 진행할 경우 localStorage에 `userId` 를 저장합니다.
- logout을 진행할 경우 `userId` 를 제거합니다.
- App 컴포넌트가 마운트 될 때 autoLogin을 진행합니다. (localStorage에 `userId` 키의 값이 존재할 경우)
- Signin page의 test 코드에 `RecoilRoot` 가 존재하지 않아 실패를 하여 `RecoilRoot` 를 추가하였습니다.

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- autoLogin을 실패할 경우에 다시 로그인 해달라는 에러 핸들링을 진행하면 좋을 것 같습니다.
